### PR TITLE
try to fix markupsafe error by fixing version to prior

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas
 matplotlib
 data-science-types
 pretty_html_table
+markupsafe==2.0.1


### PR DESCRIPTION
Try to fix this error

`ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/home/runner/.local/lib/python3.8/site-packages/markupsafe/__init__.py)`