### PR TITLE
Use latest version of markupsafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pandas
 matplotlib
 data-science-types
 pretty_html_table
-markupsafe==2.0.1


### PR DESCRIPTION
I think the problem was occurring because `ubuntu-latest` runs on Python 3.8 by default. When running with Python 3.9 as per the previous PR, it seems to work.

So I am reverting the pinned version of `markupsafe` since it doesn't seem to be necessary anymore.